### PR TITLE
bloat.py: remove unused imports

### DIFF
--- a/bloat.py
+++ b/bloat.py
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import fileinput
 import operator
 import optparse
 import os
-import pprint
 import re
 import subprocess
 import sys


### PR DESCRIPTION
Remove unused fileinput and pprint module imports

Signed-off-by: Maxin B. John <maxin.john@enea.com>